### PR TITLE
Eliminate the standalone config validation job

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -26,7 +26,7 @@ jobs:
         env:
           inputs_config: "${{ inputs.config }}"
         run: |
-          echo "$inputs_config" > config.json
+          echo "$inputs_config" > "${RUNNER_TEMP}/tox-config.json"
 
       # If a previous workflow run successfully validated an identical config object,
       # a cache hit is sufficient to demonstrate that no further validation is required.
@@ -35,8 +35,8 @@ jobs:
         uses: "actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9" # v4.0.2
         with:
           lookup-only: true
-          path: "config.json"
-          key: "config-${{ hashFiles('config.json') }}"
+          path: "${{ format('{0}/{1}', runner.temp, 'tox-config.json') }}"
+          key: "config-${{ hashFiles(format('{0}/{1}', runner.temp, 'tox-config.json')) }}"
 
       - name: "Write schema"
         if: "steps.restore-cache.outputs.cache-hit == false"
@@ -185,7 +185,7 @@ jobs:
         if: "steps.restore-cache.outputs.cache-hit == false"
         run: |
           pip install --user check-jsonschema
-          check-jsonschema --schemafile schema.json config.json
+          check-jsonschema --schemafile schema.json "${RUNNER_TEMP}/tox-config.json"
 
       - name: "Transform config"
         id: "config-transformer"
@@ -194,9 +194,10 @@ jobs:
           # START: tox-config-transformer.py
           import json
           import os
+          import pathlib
 
-          with open("config.json") as file:
-              config = json.load(file)
+          config_file_path = pathlib.Path(os.environ["RUNNER_TEMP"]) / "tox-config.json"
+          config = json.loads(config_file_path.read_text())
 
           # Transform the tox environments for convenience.
           # "pre-environments" and "post-environments" will be injected into "environments",

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -13,11 +13,9 @@ on:
         type: "string"
 
 jobs:
-  validate-config:
-    name: "Validate config"
-    outputs:
-      config: "${{ steps.config-transformer.outputs.config }}"
-    runs-on: "ubuntu-latest"
+  tox:
+    name: "tox"
+    runs-on: "${{ fromJSON(inputs.config).runner }}"
     steps:
       - name: "Export config"
         id: "config-exporter"
@@ -26,166 +24,168 @@ jobs:
         env:
           inputs_config: "${{ inputs.config }}"
         run: |
-          echo "$inputs_config" > "${RUNNER_TEMP}/tox-config.json"
+          echo "$inputs_config" > "${RUNNER_TEMP}/tox-config.raw.json"
 
       # If a previous workflow run successfully validated an identical config object,
       # a cache hit is sufficient to demonstrate that no further validation is required.
-      - name: "Restore cache"
-        id: "restore-cache"
+      - name: "Look up config cache"
+        id: "lookup-config-cache"
         uses: "actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9" # v4.0.2
         with:
           lookup-only: true
-          path: "${{ format('{0}/{1}', runner.temp, 'tox-config.json') }}"
-          key: "config-${{ hashFiles(format('{0}/{1}', runner.temp, 'tox-config.json')) }}"
+          path: "${{ format('{0}/tox-config.raw.json', runner.temp) }}"
+          key: "config-${{ hashFiles(format('{0}/tox-config.raw.json', runner.temp)) }}"
 
       - name: "Write schema"
-        if: "steps.restore-cache.outputs.cache-hit == false"
+        if: "steps.lookup-config-cache.outputs.cache-hit == false"
+        shell: "bash"
+        env:
+          tox_schema: |
+            # START: tox-schema.json
+            {
+              "$schema": "https://json-schema.org/draft-07/schema",
+              "type": "object",
+              "required": [
+                "runner"
+              ],
+              "properties": {
+                "runner": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "tox": {
+                  "type": "object",
+                  "oneOf": [
+                    {
+                      "additionalProperties": false,
+                      "required": [
+                        "environments"
+                      ],
+                      "properties": {
+                        "environments": {
+                          "$comment": "A list of tox environments to run.",
+                          "type": "array",
+                          "minItems": 1,
+                          "items": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "additionalProperties": false,
+                      "anyOf": [
+                        {"required": ["pre-environments"]},
+                        {"required": ["post-environments"]}
+                      ],
+                      "properties": {
+                        "pre-environments": {
+                          "$comment": "A list of tox environments to run before all installed Python interpreter versions.",
+                          "type": "array",
+                          "minItems": 1,
+                          "items": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "post-environments": {
+                          "$comment": "A list of tox environments to run after all installed Python interpreter versions.",
+                          "type": "array",
+                          "minItems": 1,
+                          "items": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
+                "cpythons": {
+                  "$comment": "A list of CPython interpreter versions. Typically, the *last version* listed will be the default Python interpreter when 'python' is invoked, and will be the version used when installing and executing tox.",
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "cpython-beta": {
+                  "$comment": "A CPython version to install as a beta. Unless the 'cpythons' list is empty, this version will never be the default Python interpreter.",
+                  "type": "string",
+                  "minLength": 3
+                },
+                "pypys": {
+                  "$comment": "A list of PyPy interpreter versions.",
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "cache": {
+                  "type": "object",
+                  "minProperties": 1,
+                  "properties": {
+                    "key": {
+                      "type": "object",
+                      "minProperties": 1,
+                      "properties": {
+                        "prefix": {
+                          "$comment": "A prefix to use with the cached environment key.",
+                          "type": "string",
+                          "minLength": 1,
+                          "default": "tox"
+                        },
+                        "hash-files": {
+                          "$comment": "An additional path pattern that will be added to the list of paths to include when hashing files for cache-busting.",
+                          "type": "array",
+                          "minItems": 1,
+                          "items": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        }
+                      }
+                    },
+                    "paths": {
+                      "$comment": "Additional paths to cache. Any paths specified here will be added to the default list: '.venv/' and '.tox/'.",
+                      "type": "array",
+                      "minItems": 1,
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    }
+                  }
+                }
+              },
+              "anyOf": [
+                {"required": ["cpythons"], "$comment": "At least one Python interpreter must be present."},
+                {"required": ["cpython-beta"]},
+                {"required": ["pypys"]}
+              ]
+            }
+            # END: tox-schema.json
         run: |
           # Due to the architecture of the source code synchronization code,
-          # it's necessary to have START and END lines in the bash heredoc
-          # and to strip those leading and trailing lines using 'head' and 'tail'.
-          cat << 'EOF' | head -n -1 | tail -n +2 > "schema.json"
-          # START: tox-schema.json
-          {
-            "$schema": "https://json-schema.org/draft-07/schema",
-            "type": "object",
-            "required": [
-              "runner"
-            ],
-            "properties": {
-              "runner": {
-                "type": "string",
-                "minLength": 1
-              },
-              "tox": {
-                "type": "object",
-                "oneOf": [
-                  {
-                    "additionalProperties": false,
-                    "required": [
-                      "environments"
-                    ],
-                    "properties": {
-                      "environments": {
-                        "$comment": "A list of tox environments to run.",
-                        "type": "array",
-                        "minItems": 1,
-                        "items": {
-                          "type": "string",
-                          "minLength": 1
-                        }
-                      }
-                    }
-                  },
-                  {
-                    "additionalProperties": false,
-                    "anyOf": [
-                      {"required": ["pre-environments"]},
-                      {"required": ["post-environments"]}
-                    ],
-                    "properties": {
-                      "pre-environments": {
-                        "$comment": "A list of tox environments to run before all installed Python interpreter versions.",
-                        "type": "array",
-                        "minItems": 1,
-                        "items": {
-                          "type": "string",
-                          "minLength": 1
-                        }
-                      },
-                      "post-environments": {
-                        "$comment": "A list of tox environments to run after all installed Python interpreter versions.",
-                        "type": "array",
-                        "minItems": 1,
-                        "items": {
-                          "type": "string",
-                          "minLength": 1
-                        }
-                      }
-                    }
-                  }
-                ]
-              },
-              "cpythons": {
-                "$comment": "A list of CPython interpreter versions. Typically, the *last version* listed will be the default Python interpreter when 'python' is invoked, and will be the version used when installing and executing tox.",
-                "type": "array",
-                "minItems": 1,
-                "items": {
-                  "type": "string",
-                  "minLength": 1
-                }
-              },
-              "cpython-beta": {
-                "$comment": "A CPython version to install as a beta. Unless the 'cpythons' list is empty, this version will never be the default Python interpreter.",
-                "type": "string",
-                "minLength": 3
-              },
-              "pypys": {
-                "$comment": "A list of PyPy interpreter versions.",
-                "type": "array",
-                "minItems": 1,
-                "items": {
-                  "type": "string",
-                  "minLength": 1
-                }
-              },
-              "cache": {
-                "type": "object",
-                "minProperties": 1,
-                "properties": {
-                  "key": {
-                    "type": "object",
-                    "minProperties": 1,
-                    "properties": {
-                      "prefix": {
-                        "$comment": "A prefix to use with the cached environment key.",
-                        "type": "string",
-                        "minLength": 1,
-                        "default": "tox"
-                      },
-                      "hash-files": {
-                        "$comment": "An additional path pattern that will be added to the list of paths to include when hashing files for cache-busting.",
-                        "type": "array",
-                        "minItems": 1,
-                        "items": {
-                          "type": "string",
-                          "minLength": 1
-                        }
-                      }
-                    }
-                  },
-                  "paths": {
-                    "$comment": "Additional paths to cache. Any paths specified here will be added to the default list: '.venv/' and '.tox/'.",
-                    "type": "array",
-                    "minItems": 1,
-                    "items": {
-                      "type": "string",
-                      "minLength": 1
-                    }
-                  }
-                }
-              }
-            },
-            "anyOf": [
-              {"required": ["cpythons"], "$comment": "At least one Python interpreter must be present."},
-              {"required": ["cpython-beta"]},
-              {"required": ["pypys"]}
-            ]
-          }
-          # END: tox-schema.json
-          EOF
+          # the START and END lines in the JSON schema above must be removed.
+          echo "${tox_schema}" | grep -ve '^#' > "${RUNNER_TEMP}/tox-schema.json"
 
       - name: "Setup Python for validation"
-        if: "steps.restore-cache.outputs.cache-hit == false"
+        if: "steps.lookup-config-cache.outputs.cache-hit == false"
         uses: "actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3" # v5.2.0
         with:
           python-version: "3.12"
 
       - name: "Validate the config against the schema"
-        if: "steps.restore-cache.outputs.cache-hit == false"
+        if: "steps.lookup-config-cache.outputs.cache-hit == false"
+        shell: "bash"
         run: |
-          pip install --user check-jsonschema
-          check-jsonschema --schemafile schema.json "${RUNNER_TEMP}/tox-config.json"
+          pip install --target="${RUNNER_TEMP}/check-jsonschema" check-jsonschema
+          PYTHONPATH="${RUNNER_TEMP}/check-jsonschema" "${RUNNER_TEMP}/check-jsonschema/bin/check-jsonschema" --schemafile "${RUNNER_TEMP}/tox-schema.json" "${RUNNER_TEMP}/tox-config.raw.json"
 
       - name: "Transform config"
         id: "config-transformer"
@@ -196,8 +196,9 @@ jobs:
           import os
           import pathlib
 
-          config_file_path = pathlib.Path(os.environ["RUNNER_TEMP"]) / "tox-config.json"
-          config = json.loads(config_file_path.read_text())
+          runner_temp = pathlib.Path(os.environ["RUNNER_TEMP"])
+          raw_config_path = runner_temp / "tox-config.raw.json"
+          config = json.loads(raw_config_path.read_text())
 
           # Transform the tox environments for convenience.
           # "pre-environments" and "post-environments" will be injected into "environments",
@@ -214,24 +215,19 @@ jobs:
               config["tox"]["environments"] = environments
 
           output = json.dumps(config, sort_keys=True, separators=(",", ":"))
-          with open(os.environ["GITHUB_OUTPUT"], "a") as file:
-              file.write(f"config={output}")
+          with open(os.environ["GITHUB_ENV"], "a") as file:
+              file.write(f"tox-config={output}")
+          (runner_temp / "tox-config.json").write_text(output)
           # END: tox-config-transformer.py
 
-  tox:
-    needs:
-      - "validate-config"
-    name: "Run tests"
-    runs-on: "${{ fromJSON(inputs.config).runner }}"
-    steps:
       - name: "Checkout the repository"
         uses: "actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332" # v4.1.7
 
       - name: "Calculate additional checksums"
-        if: "fromJSON(inputs.config).cache.hash-files"
+        if: "fromJSON(env.tox-config).cache.hash-files"
         shell: "bash"
         env:
-          FILE_PATTERNS: "${{ join(fromJSON(inputs.config).cache.hash-files, ' ') }}"
+          FILE_PATTERNS: "${{ join(fromJSON(env.tox-config).cache.hash-files, ' ') }}"
         run: |
           # shellcheck disable=SC2086
           for pattern in $FILE_PATTERNS; do
@@ -257,9 +253,9 @@ jobs:
           python-version: "${{
               format(
                 '{0}{1}{2}',
-                fromJSON(inputs.config).pypys && format('pypy{0}\n', join(fromJSON(inputs.config).pypys, '\npypy')) || '',
-                fromJSON(inputs.config).cpython-beta && format('{0}\n', fromJSON(inputs.config).cpython-beta ) || '',
-                fromJSON(inputs.config).cpythons && join(fromJSON(inputs.config).cpythons, '\n') || ''
+                fromJSON(env.tox-config).pypys && format('pypy{0}\n', join(fromJSON(env.tox-config).pypys, '\npypy')) || '',
+                fromJSON(env.tox-config).cpython-beta && format('{0}\n', fromJSON(env.tox-config).cpython-beta ) || '',
+                fromJSON(env.tox-config).cpythons && join(fromJSON(env.tox-config).cpythons, '\n') || ''
               )
             }}"
           allow-prereleases: true
@@ -270,8 +266,8 @@ jobs:
       - name: "Write the workflow config"
         shell: "bash"
         run: |
-          cat << 'EOF' > .workflow-config.json
-          ${{ needs.validate-config.outputs.config }}
+          cat << 'EOF' > .tox-config.json
+          ${{ env.tox-config }}
           EOF
 
       - name: "Restore cache"
@@ -281,8 +277,20 @@ jobs:
           path: |
             .tox/
             .venv/
-            ${{ fromJSON(inputs.config).cache.paths && join(fromJSON(inputs.config).cache.paths, '\n') }}
-          key: "${{ fromJSON(inputs.config).cache.name || 'tox' }}-os=${{ fromJSON(inputs.config).runner }}-hash=${{ hashFiles('.python-identifiers', '.workflow-config.json', 'tox.ini', fromJSON(inputs.config).cache.key.hash-files && '.hash-files.sha') }}"
+            ${{ fromJSON(env.tox-config).cache.paths && join(fromJSON(env.tox-config).cache.paths, '\n') }}
+          key: "${{
+            format(
+              '{0}-os={1}-hash={2}',
+              fromJSON(env.tox-config).cache.name || 'tox',
+              fromJSON(env.tox-config).runner,
+              hashFiles(
+                '.python-identifiers',
+                format('{0}/tox-config.json', runner.temp),
+                'tox.ini',
+                fromJSON(env.tox-config).cache.key.hash-files && '.hash-files.sha' || ''
+              )
+            )
+          }}"
 
       - name: "Identify .venv path"
         shell: "bash"
@@ -298,4 +306,4 @@ jobs:
 
       - name: "Run the test suite"
         run: |
-          ${{ env.venv-path }}/tox run --colored yes ${{ fromJSON(needs.validate-config.outputs.config).tox.environments && format('-e "{0}"', join(fromJSON(needs.validate-config.outputs.config).tox.environments, ',')) }}
+          ${{ env.venv-path }}/tox run --colored yes ${{ fromJSON(env.tox-config).tox.environments && format('-e "{0}"', join(fromJSON(env.tox-config).tox.environments, ',')) }}

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -19,11 +19,6 @@ jobs:
       config: "${{ steps.config-transformer.outputs.config }}"
     runs-on: "ubuntu-latest"
     steps:
-      - name: "Setup Python"
-        uses: "actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3" # v5.2.0
-        with:
-          python-version: "3.12"
-
       - name: "Export config"
         id: "config-exporter"
         shell: "bash"
@@ -179,6 +174,12 @@ jobs:
           }
           # END: tox-schema.json
           EOF
+
+      - name: "Setup Python for validation"
+        if: "steps.restore-cache.outputs.cache-hit == false"
+        uses: "actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3" # v5.2.0
+        with:
+          python-version: "3.12"
 
       - name: "Validate the config against the schema"
         if: "steps.restore-cache.outputs.cache-hit == false"

--- a/changelog.d/20240903_204323_kurtmckee_single_job_tox_workflow.rst
+++ b/changelog.d/20240903_204323_kurtmckee_single_job_tox_workflow.rst
@@ -1,0 +1,6 @@
+Changed
+-------
+
+-   Merge the standalone 'Validate config' job into the 'Run tests' job.
+
+    This is likely to reduce billable CI time in paid repos.

--- a/src/tox-config-transformer.py
+++ b/src/tox-config-transformer.py
@@ -5,9 +5,10 @@
 
 import json
 import os
+import pathlib
 
-with open("config.json") as file:
-    config = json.load(file)
+config_file_path = pathlib.Path(os.environ["RUNNER_TEMP"]) / "tox-config.json"
+config = json.loads(config_file_path.read_text())
 
 # Transform the tox environments for convenience.
 # "pre-environments" and "post-environments" will be injected into "environments",

--- a/src/tox-config-transformer.py
+++ b/src/tox-config-transformer.py
@@ -7,8 +7,9 @@ import json
 import os
 import pathlib
 
-config_file_path = pathlib.Path(os.environ["RUNNER_TEMP"]) / "tox-config.json"
-config = json.loads(config_file_path.read_text())
+runner_temp = pathlib.Path(os.environ["RUNNER_TEMP"])
+raw_config_path = runner_temp / "tox-config.raw.json"
+config = json.loads(raw_config_path.read_text())
 
 # Transform the tox environments for convenience.
 # "pre-environments" and "post-environments" will be injected into "environments",
@@ -25,5 +26,6 @@ if {"pre-environments", "post-environments"} & config.get("tox", {}).keys():
     config["tox"]["environments"] = environments
 
 output = json.dumps(config, sort_keys=True, separators=(",", ":"))
-with open(os.environ["GITHUB_OUTPUT"], "a") as file:
-    file.write(f"config={output}")
+with open(os.environ["GITHUB_ENV"], "a") as file:
+    file.write(f"tox-config={output}")
+(runner_temp / "tox-config.json").write_text(output)


### PR DESCRIPTION
Changed
-------

-   Merge the standalone 'Validate config' job into the 'Run tests' job.

    This is likely to reduce billable CI time in paid repos.
