### PR TITLE
Fix 'config-is-validated' caching

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -172,17 +172,12 @@ jobs:
           pip install --target="${RUNNER_TEMP}/check-jsonschema" check-jsonschema
           PYTHONPATH="${RUNNER_TEMP}/check-jsonschema" "${RUNNER_TEMP}/check-jsonschema/bin/check-jsonschema" --schemafile "${RUNNER_TEMP}/tox-schema.json" ".tox-config.raw.json"
 
-      - name: "Create an empty 'tox-config-is-validated' flag file"
-        shell: "bash"
-        run: |
-          touch ".tox-config-is-validated.flag"
-
       - name: "Create a 'config-is-validated' cache key"
         if: "steps.lookup-config-cache.outputs.cache-hit == false"
         uses: "actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9" # v4.0.2
         with:
-          path: ".tox-config-is-validated.flag"
-          key: "config-${{ hashFiles('.tox-config.raw.json') }}"
+          path: ".tox-config.raw.json"
+          key: "${{ steps.lookup-config-cache.outputs.cache-primary-key }}"
 
       - name: "Transform tox config"
         id: "config-transformer"

--- a/changelog.d/20240909_105636_kurtmckee_fix_caching.rst
+++ b/changelog.d/20240909_105636_kurtmckee_fix_caching.rst
@@ -1,0 +1,6 @@
+Fixed
+-----
+
+-   Fix 'config-is-validated' caching.
+
+    ``actions/cache`` needs the ``path`` values to match between restore and save steps.


### PR DESCRIPTION
Fixed
-----

-   Fix 'config-is-validated' caching.

    ``actions/cache`` needs the ``path`` values to match between restore and save steps.
