### PR TITLE
Use the ``tox-uv`` plugin to speed up tox environment creation

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -307,7 +307,7 @@ jobs:
         run: |
           python -m venv .venv
           ${{ env.venv-path }}/python -m pip install --upgrade pip setuptools wheel
-          ${{ env.venv-path }}/pip install tox
+          ${{ env.venv-path }}/pip install tox tox-uv
 
       - name: "Run the test suite"
         run: |

--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,7 @@ The ``tox.yaml`` workflow in this repo has the following features:
 *   Multiple CPython/PyPy interpreter versions per runner
 *   Selectable tox environments
 *   Schema validation of the inputs passed to the workflow
+*   Fast tox environment creation using the ``tox-uv`` plugin
 *   Built-in caching of tox and virtual environments with strong cache-busting
 
 

--- a/changelog.d/20241102_161110_kurtmckee_use_tox_uv.rst
+++ b/changelog.d/20241102_161110_kurtmckee_use_tox_uv.rst
@@ -1,0 +1,4 @@
+Changed
+-------
+
+-   Use the ``tox-uv`` plugin to speed up tox environment creation.


### PR DESCRIPTION
Changed
-------

-   Use the ``tox-uv`` plugin to speed up tox environment creation.
