### PR TITLE
Add additional config options

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -221,22 +221,37 @@ jobs:
               # no config data are lost in this transformation.
               tox_factors = config.pop("tox-factors", [])
               factors = f"-{'-'.join(tox_factors)}" if tox_factors else ""
+              cpythons = config.get("cpythons", [])
+              cpython_beta = config.get("cpython-beta")
+              pypys = config.get("pypys", [])
+
               if (
                   factors
                   or config.pop("tox-environments-from-pythons", False)
                   or {"tox-pre-environments", "tox-post-environments"} & config.keys()
               ):
                   environments = config.pop("tox-pre-environments", [])
-                  environments.extend(
-                      f"py{version}{factors}" for version in config.get("cpythons", [])
-                  )
-                  if "cpython-beta" in config:
-                      environments.append(f"py{config['cpython-beta']}{factors}")
-                  environments.extend(
-                      f"pypy{version}{factors}" for version in config.get("pypys", [])
-                  )
+                  environments.extend(f"py{version}{factors}" for version in cpythons)
+                  if cpython_beta is not None:
+                      environments.append(f"py{cpython_beta}{factors}")
+                  environments.extend(f"pypy{version}{factors}" for version in pypys)
                   environments.extend(config.pop("tox-post-environments", []))
                   config["tox-environments"] = environments
+
+              python_versions_requested = [f"pypy{version}" for version in pypys]
+              if cpython_beta is not None:
+                  python_versions_requested.append(cpython_beta)
+              python_versions_requested.extend(cpythons)
+
+              # Because tox only offers "best effort" PyPy support,
+              # and because tox may not support CPython alphas or betas,
+              # a stable CPython version must be included during initial Python setup.
+              python_versions_required = python_versions_requested.copy()
+              if not cpythons:
+                  python_versions_required.append("3.12")
+
+              config["python-versions-requested"] = "\n".join(python_versions_requested)
+              config["python-versions-required"] = "\n".join(python_versions_required)
 
 
           def main() -> None:
@@ -283,26 +298,12 @@ jobs:
           done
           cat .hash-files.sha
 
-      - name: "Setup Pythons"
+      - name: "Setup Pythons (required)"
         uses: "actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b" # v5.3.0
         env:
-          # PyPy on macOS may warn about old pip versions during installation.
           PIP_DISABLE_PIP_VERSION_CHECK: "1"
         with:
-          # Python interpreter versions are ordered:
-          #
-          # * PyPy versions
-          # * CPython beta version
-          # * CPython versions
-          #
-          python-version: "${{
-              format(
-                '{0}{1}{2}',
-                fromJSON(env.tox-config).pypys && format('pypy{0}\n', join(fromJSON(env.tox-config).pypys, '\npypy')) || '',
-                fromJSON(env.tox-config).cpython-beta && format('{0}\n', fromJSON(env.tox-config).cpython-beta ) || '',
-                fromJSON(env.tox-config).cpythons && join(fromJSON(env.tox-config).cpythons, '\n') || ''
-              )
-            }}"
+          python-version: "${{ fromJSON(env.tox-config).python-versions-required }}"
           allow-prereleases: true
 
       - name: "Detect Pythons"
@@ -341,6 +342,15 @@ jobs:
           python -m venv .venv
           ${{ env.venv-path }}/python -m pip install --upgrade pip setuptools wheel
           ${{ env.venv-path }}/pip install tox tox-uv
+
+      - name: "Setup Pythons (requested)"
+        if: "fromJSON(env.tox-config).python-versions-required != fromJSON(env.tox-config).python-versions-requested"
+        uses: "actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b" # v5.3.0
+        env:
+          PIP_DISABLE_PIP_VERSION_CHECK: "1"
+        with:
+          python-version: "${{ fromJSON(env.tox-config).python-versions-requested }}"
+          allow-prereleases: true
 
       - name: "Run the test suite"
         run: |

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -67,6 +67,15 @@ jobs:
                   "type": "boolean",
                   "enum": [true]
                 },
+                "tox-factors": {
+                  "$comment": "A list of factors to append to the generated names of tox environments.",
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
                 "tox-pre-environments": {
                   "$comment": "A list of tox environments to run before all installed Python interpreter versions.",
                   "type": "array",
@@ -151,6 +160,10 @@ jobs:
                         "not": {"required": ["tox-environments-from-pythons"]}
                       },
                       {
+                        "$comment": "tox-environments is mutually exclusive with tox-factors.",
+                        "not": {"required": ["tox-factors"]}
+                      },
+                      {
                         "$comment": "tox-environments is mutually exclusive with tox-pre-environments.",
                         "not": {"required": ["tox-pre-environments"]}
                       },
@@ -206,15 +219,22 @@ jobs:
               # together with a full list of CPython and PyPy interpreter versions.
               # Since these keys are mutually-exclusive with "tox-environments",
               # no config data are lost in this transformation.
+              tox_factors = config.pop("tox-factors", [])
+              factors = f"-{'-'.join(tox_factors)}" if tox_factors else ""
               if (
-                  config.pop("tox-environments-from-pythons", False)
+                  factors
+                  or config.pop("tox-environments-from-pythons", False)
                   or {"tox-pre-environments", "tox-post-environments"} & config.keys()
               ):
                   environments = config.pop("tox-pre-environments", [])
-                  environments.extend(f"py{version}" for version in config.get("cpythons", []))
+                  environments.extend(
+                      f"py{version}{factors}" for version in config.get("cpythons", [])
+                  )
                   if "cpython-beta" in config:
-                      environments.append(f"py{config['cpython-beta']}")
-                  environments.extend(f"pypy{version}" for version in config.get("pypys", []))
+                      environments.append(f"py{config['cpython-beta']}{factors}")
+                  environments.extend(
+                      f"pypy{version}{factors}" for version in config.get("pypys", [])
+                  )
                   environments.extend(config.pop("tox-post-environments", []))
                   config["tox-environments"] = environments
 

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -62,6 +62,11 @@ jobs:
                     "minLength": 1
                   }
                 },
+                "tox-environments-from-pythons": {
+                  "$comment": "Generate a list of tox environments from the list of all configured Python interpreters.",
+                  "type": "boolean",
+                  "enum": [true]
+                },
                 "tox-pre-environments": {
                   "$comment": "A list of tox environments to run before all installed Python interpreter versions.",
                   "type": "array",
@@ -142,12 +147,17 @@ jobs:
                   "then": {
                     "allOf": [
                       {
+                        "$comment": "tox-environments is mutually exclusive with tox-environments-from-pythons.",
+                        "not": {"required": ["tox-environments-from-pythons"]}
+                      },
+                      {
                         "$comment": "tox-environments is mutually exclusive with tox-pre-environments.",
                         "not": {"required": ["tox-pre-environments"]}
                       },
                       {
                         "$comment": "tox-environments is mutually exclusive with tox-post-environments.",
-                        "not": {"required": ["tox-post-environments"]}}
+                        "not": {"required": ["tox-post-environments"]}
+                      }
                     ]
                   }
                 }
@@ -196,7 +206,10 @@ jobs:
               # together with a full list of CPython and PyPy interpreter versions.
               # Since these keys are mutually-exclusive with "tox-environments",
               # no config data are lost in this transformation.
-              if {"tox-pre-environments", "tox-post-environments"} & config.keys():
+              if (
+                  config.pop("tox-environments-from-pythons", False)
+                  or {"tox-pre-environments", "tox-post-environments"} & config.keys()
+              ):
                   environments = config.pop("tox-pre-environments", [])
                   environments.extend(f"py{version}" for version in config.get("cpythons", []))
                   if "cpython-beta" in config:

--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,7 @@ Config keys
     Mutually-exclusive with:
 
     *   ``tox-environments-from-pythons``
+    *   ``tox-factors``
     *   ``tox-pre-environments``
     *   ``tox-post-environments``
 
@@ -114,6 +115,30 @@ Config keys
 
         tox run -e "py3.12,py3.13,py3.14,pypy3.10"
                     ^^^^^^ ^^^^^^ ^^^^^^ ^^^^^^^^
+
+*   ``tox-factors``:
+    An array of factors to add to the ends of generated tox environment names.
+
+    Configuring this key automatically enables ``tox-environments-from-pythons``.
+
+    Mutually-exclusive with ``tox-environments``.
+
+    Example:
+
+    ..  code-block:: yaml
+
+        cpythons:
+          - "3.12"
+          - "3.13"
+        tox-factors:
+          - "ci"
+
+    Resulting tox command:
+
+    ..  code-block::
+
+        tox run -e "py3.12-ci,py3.13-ci"
+                          ^^^       ^^^
 
 *   ``tox-pre-environments``:
     An array of tox environments to run

--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,12 @@ Config keys
 
 *   ``tox-environments``:
     An array of tox environments to run. Items must be strings.
-    Mutually-exclusive with ``tox-pre-environments`` and ``tox-post-environments``.
+
+    Mutually-exclusive with:
+
+    *   ``tox-environments-from-pythons``
+    *   ``tox-pre-environments``
+    *   ``tox-post-environments``
 
     Example:
 
@@ -81,10 +86,41 @@ Config keys
     ..  code-block::
 
         tox run -e "docs,mypy"
+                    ^^^^ ^^^^
+
+*   ``tox-environments-from-pythons``:
+    A boolean flag that controls whether the configured Python interpreters
+    will be converted to a list of specific tox environments to execute.
+
+    If configured, the only allowed value is ``true``.
+
+    Mutually-exclusive with ``tox-environments``.
+
+    Example:
+
+    ..  code-block:: yaml
+
+        cpythons:
+          - "3.12"
+          - "3.13"
+        cpython-beta: "3.14"
+        pypys:
+          - "3.10"
+        tox-environments-from-pythons: true
+
+    Resulting tox command:
+
+    ..  code-block::
+
+        tox run -e "py3.12,py3.13,py3.14,pypy3.10"
+                    ^^^^^^ ^^^^^^ ^^^^^^ ^^^^^^^^
 
 *   ``tox-pre-environments``:
-    An array of of tox environments to run
-    before a generated list of all CPython and PyPy environments.
+    An array of tox environments to run
+    before a generated list of all configured Python interpreters as tox environments.
+
+    Configuring this key automatically enables ``tox-environments-from-pythons``.
+
     Mutually-exclusive with ``tox-environments``.
 
     Example:
@@ -103,10 +139,14 @@ Config keys
     ..  code-block::
 
         tox run -e "flake8,py3.11,pypy3.10"
+                    ^^^^^^
 
 *   ``tox-post-environments``:
-    An array of of tox environments to run
-    after a generated list of all CPython and PyPy environments.
+    An array of tox environments to run
+    after a generated list of all configured Python interpreters as tox environments.
+
+    Configuring this key automatically enables ``tox-environments-from-pythons``.
+
     Mutually-exclusive with ``tox-environments``.
 
     Example:
@@ -125,6 +165,7 @@ Config keys
     ..  code-block::
 
         tox run -e "py3.11,pypy3.10,coverage"
+                                    ^^^^^^^^
 
 *   ``cache-paths``:
     An array of additional paths to cache.

--- a/changelog.d/20241104_064842_kurtmckee_enumerate_pythons.rst
+++ b/changelog.d/20241104_064842_kurtmckee_enumerate_pythons.rst
@@ -1,0 +1,6 @@
+Added
+-----
+
+-   Add a ``tox-environments-from-pythons`` boolean key
+    which will cause a list of tox environments to be generated
+    from the list of all configured Python interpreters.

--- a/changelog.d/20241104_175742_kurtmckee_enumerate_pythons.rst
+++ b/changelog.d/20241104_175742_kurtmckee_enumerate_pythons.rst
@@ -1,0 +1,5 @@
+Added
+-----
+
+-   Add a ``tox-factors`` config option that will auto-append the factors
+    to generated tox environment names.

--- a/changelog.d/20241105_065725_kurtmckee_enumerate_pythons.rst
+++ b/changelog.d/20241105_065725_kurtmckee_enumerate_pythons.rst
@@ -1,0 +1,11 @@
+Changed
+-------
+
+-   Guarantee that a stable CPython interpreter is available for tox to use.
+
+    Because tox only offers "best effort" support for PyPy,
+    and might not support a given CPython alpha or beta,
+    CPython 3.12 will now be set up automatically for tox to use.
+
+    Just prior to running tox, ``actions/setup-python`` will be run again
+    to ensure that only the requested Python interpreters are on the PATH.

--- a/src/tox-schema.json
+++ b/src/tox-schema.json
@@ -18,6 +18,11 @@
         "minLength": 1
       }
     },
+    "tox-environments-from-pythons": {
+      "$comment": "Generate a list of tox environments from the list of all configured Python interpreters.",
+      "type": "boolean",
+      "enum": [true]
+    },
     "tox-pre-environments": {
       "$comment": "A list of tox environments to run before all installed Python interpreter versions.",
       "type": "array",
@@ -98,12 +103,17 @@
       "then": {
         "allOf": [
           {
+            "$comment": "tox-environments is mutually exclusive with tox-environments-from-pythons.",
+            "not": {"required": ["tox-environments-from-pythons"]}
+          },
+          {
             "$comment": "tox-environments is mutually exclusive with tox-pre-environments.",
             "not": {"required": ["tox-pre-environments"]}
           },
           {
             "$comment": "tox-environments is mutually exclusive with tox-post-environments.",
-            "not": {"required": ["tox-post-environments"]}}
+            "not": {"required": ["tox-post-environments"]}
+          }
         ]
       }
     }

--- a/src/tox-schema.json
+++ b/src/tox-schema.json
@@ -23,6 +23,15 @@
       "type": "boolean",
       "enum": [true]
     },
+    "tox-factors": {
+      "$comment": "A list of factors to append to the generated names of tox environments.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
     "tox-pre-environments": {
       "$comment": "A list of tox environments to run before all installed Python interpreter versions.",
       "type": "array",
@@ -105,6 +114,10 @@
           {
             "$comment": "tox-environments is mutually exclusive with tox-environments-from-pythons.",
             "not": {"required": ["tox-environments-from-pythons"]}
+          },
+          {
+            "$comment": "tox-environments is mutually exclusive with tox-factors.",
+            "not": {"required": ["tox-factors"]}
           },
           {
             "$comment": "tox-environments is mutually exclusive with tox-pre-environments.",

--- a/src/tox_config_transformer.py
+++ b/src/tox_config_transformer.py
@@ -17,22 +17,37 @@ def transform_config(config: dict[str, typing.Any]):
     # no config data are lost in this transformation.
     tox_factors = config.pop("tox-factors", [])
     factors = f"-{'-'.join(tox_factors)}" if tox_factors else ""
+    cpythons = config.get("cpythons", [])
+    cpython_beta = config.get("cpython-beta")
+    pypys = config.get("pypys", [])
+
     if (
         factors
         or config.pop("tox-environments-from-pythons", False)
         or {"tox-pre-environments", "tox-post-environments"} & config.keys()
     ):
         environments = config.pop("tox-pre-environments", [])
-        environments.extend(
-            f"py{version}{factors}" for version in config.get("cpythons", [])
-        )
-        if "cpython-beta" in config:
-            environments.append(f"py{config['cpython-beta']}{factors}")
-        environments.extend(
-            f"pypy{version}{factors}" for version in config.get("pypys", [])
-        )
+        environments.extend(f"py{version}{factors}" for version in cpythons)
+        if cpython_beta is not None:
+            environments.append(f"py{cpython_beta}{factors}")
+        environments.extend(f"pypy{version}{factors}" for version in pypys)
         environments.extend(config.pop("tox-post-environments", []))
         config["tox-environments"] = environments
+
+    python_versions_requested = [f"pypy{version}" for version in pypys]
+    if cpython_beta is not None:
+        python_versions_requested.append(cpython_beta)
+    python_versions_requested.extend(cpythons)
+
+    # Because tox only offers "best effort" PyPy support,
+    # and because tox may not support CPython alphas or betas,
+    # a stable CPython version must be included during initial Python setup.
+    python_versions_required = python_versions_requested.copy()
+    if not cpythons:
+        python_versions_required.append("3.12")
+
+    config["python-versions-requested"] = "\n".join(python_versions_requested)
+    config["python-versions-required"] = "\n".join(python_versions_required)
 
 
 def main() -> None:

--- a/src/tox_config_transformer.py
+++ b/src/tox_config_transformer.py
@@ -15,7 +15,10 @@ def transform_config(config: dict[str, typing.Any]):
     # together with a full list of CPython and PyPy interpreter versions.
     # Since these keys are mutually-exclusive with "tox-environments",
     # no config data are lost in this transformation.
-    if {"tox-pre-environments", "tox-post-environments"} & config.keys():
+    if (
+        config.pop("tox-environments-from-pythons", False)
+        or {"tox-pre-environments", "tox-post-environments"} & config.keys()
+    ):
         environments = config.pop("tox-pre-environments", [])
         environments.extend(f"py{version}" for version in config.get("cpythons", []))
         if "cpython-beta" in config:

--- a/src/tox_config_transformer.py
+++ b/src/tox_config_transformer.py
@@ -15,15 +15,22 @@ def transform_config(config: dict[str, typing.Any]):
     # together with a full list of CPython and PyPy interpreter versions.
     # Since these keys are mutually-exclusive with "tox-environments",
     # no config data are lost in this transformation.
+    tox_factors = config.pop("tox-factors", [])
+    factors = f"-{'-'.join(tox_factors)}" if tox_factors else ""
     if (
-        config.pop("tox-environments-from-pythons", False)
+        factors
+        or config.pop("tox-environments-from-pythons", False)
         or {"tox-pre-environments", "tox-post-environments"} & config.keys()
     ):
         environments = config.pop("tox-pre-environments", [])
-        environments.extend(f"py{version}" for version in config.get("cpythons", []))
+        environments.extend(
+            f"py{version}{factors}" for version in config.get("cpythons", [])
+        )
         if "cpython-beta" in config:
-            environments.append(f"py{config['cpython-beta']}")
-        environments.extend(f"pypy{version}" for version in config.get("pypys", []))
+            environments.append(f"py{config['cpython-beta']}{factors}")
+        environments.extend(
+            f"pypy{version}{factors}" for version in config.get("pypys", [])
+        )
         environments.extend(config.pop("tox-post-environments", []))
         config["tox-environments"] = environments
 

--- a/tests/test_tox_config_transformer.py
+++ b/tests/test_tox_config_transformer.py
@@ -1,6 +1,8 @@
 import pathlib
 import sys
 
+import pytest
+
 src_path = pathlib.Path(__file__).parent.parent / "src"
 sys.path.append(str(src_path))
 
@@ -107,3 +109,36 @@ def test_tox_factors():
         "pypy3.10-a-b",
         "post",
     ]
+
+
+@pytest.mark.parametrize(
+    "key, value, expected",
+    (
+        ("cpython-beta", "3.14", "3.14"),
+        ("pypys", ["3.10"], "pypy3.10"),
+    ),
+)
+def test_tox_stable_cpython_injection(key, value, expected):
+    """Verify that a stable CPython version is injected."""
+
+    config = {
+        "runner": "ubuntu-latest",
+        key: value,
+    }
+
+    tox_config_transformer.transform_config(config)
+    assert config["python-versions-requested"] == expected
+    assert config["python-versions-required"] == expected + "\n3.12"
+
+
+def test_tox_stable_cpython_injection_unnecessary():
+    """Verify that no stable CPython is injected when stable CPythons are available."""
+
+    config = {
+        "runner": "ubuntu-latest",
+        "cpythons": ["3.13"],
+    }
+
+    tox_config_transformer.transform_config(config)
+    assert config["python-versions-requested"] == "3.13"
+    assert config["python-versions-required"] == "3.13"

--- a/tests/test_tox_config_transformer.py
+++ b/tests/test_tox_config_transformer.py
@@ -24,6 +24,7 @@ def test_tox_pre_post_environments():
 
     tox_config_transformer.transform_config(config)
     assert "tox-environments-from-pythons" not in config
+    assert "tox-factors" not in config
     assert "tox-pre-environments" not in config
     assert "tox-post-environments" not in config
     assert config["tox-environments"] == [
@@ -48,6 +49,7 @@ def test_tox_environments():
 
     tox_config_transformer.transform_config(config)
     assert "tox-environments-from-pythons" not in config
+    assert "tox-factors" not in config
     assert "tox-pre-environments" not in config
     assert "tox-post-environments" not in config
     assert config["tox-environments"] == [
@@ -70,10 +72,38 @@ def test_tox_pythons_as_environments():
 
     tox_config_transformer.transform_config(config)
     assert "tox-environments-from-pythons" not in config
+    assert "tox-factors" not in config
     assert "tox-pre-environments" not in config
     assert "tox-post-environments" not in config
     assert config["tox-environments"] == [
         "py3.13",
         "py3.14",
         "pypy3.10",
+    ]
+
+
+def test_tox_factors():
+    """Verify factors are only appended to generated tox environment names."""
+
+    config = {
+        "runner": "ubuntu-latest",
+        "cpythons": ["3.13"],
+        "cpython-beta": "3.14",
+        "pypys": ["3.10"],
+        "tox-factors": ["a", "b"],
+        "tox-pre-environments": ["pre"],
+        "tox-post-environments": ["post"],
+    }
+
+    tox_config_transformer.transform_config(config)
+    assert "tox-environments-from-pythons" not in config
+    assert "tox-factors" not in config
+    assert "tox-pre-environments" not in config
+    assert "tox-post-environments" not in config
+    assert config["tox-environments"] == [
+        "pre",
+        "py3.13-a-b",
+        "py3.14-a-b",
+        "pypy3.10-a-b",
+        "post",
     ]

--- a/tests/test_tox_config_transformer.py
+++ b/tests/test_tox_config_transformer.py
@@ -7,7 +7,7 @@ sys.path.append(str(src_path))
 import tox_config_transformer  # noqa: E402
 
 
-def test_tox_pre_post_environments(monkeypatch):
+def test_tox_pre_post_environments():
     """Verify tox pre- and post- environment keys are transformed."""
 
     config = {
@@ -23,6 +23,7 @@ def test_tox_pre_post_environments(monkeypatch):
     }
 
     tox_config_transformer.transform_config(config)
+    assert "tox-environments-from-pythons" not in config
     assert "tox-pre-environments" not in config
     assert "tox-post-environments" not in config
     assert config["tox-environments"] == [
@@ -34,7 +35,7 @@ def test_tox_pre_post_environments(monkeypatch):
     ]
 
 
-def test_tox_environments(monkeypatch):
+def test_tox_environments():
     """Verify explicit tox environments are not transformed."""
 
     config = {
@@ -46,10 +47,33 @@ def test_tox_environments(monkeypatch):
     }
 
     tox_config_transformer.transform_config(config)
+    assert "tox-environments-from-pythons" not in config
     assert "tox-pre-environments" not in config
     assert "tox-post-environments" not in config
     assert config["tox-environments"] == [
         "a",
         "c",
         "b",
+    ]
+
+
+def test_tox_pythons_as_environments():
+    """Verify Pythons are used to generate a list of tox environments."""
+
+    config = {
+        "runner": "ubuntu-latest",
+        "cpythons": ["3.13"],
+        "cpython-beta": "3.14",
+        "pypys": ["3.10"],
+        "tox-environments-from-pythons": True,
+    }
+
+    tox_config_transformer.transform_config(config)
+    assert "tox-environments-from-pythons" not in config
+    assert "tox-pre-environments" not in config
+    assert "tox-post-environments" not in config
+    assert config["tox-environments"] == [
+        "py3.13",
+        "py3.14",
+        "pypy3.10",
     ]

--- a/tests/test_tox_schema.py
+++ b/tests/test_tox_schema.py
@@ -71,6 +71,7 @@ def test_allow_tox_pre_post_environments(tox_schema, pop_key):
 
 mutex_keys = (
     "tox-environments-from-pythons",
+    "tox-factors",
     "tox-pre-environments",
     "tox-post-environments",
 )
@@ -86,6 +87,7 @@ def test_tox_environments_mutex(tox_schema, pop_keys):
         "cpythons": ["3.12"],
         "tox-environments": ["in"],
         "tox-environments-from-pythons": True,
+        "tox-factors": ["factor"],
         "tox-pre-environments": ["pre"],
         "tox-post-environments": ["post"],
     }
@@ -114,6 +116,7 @@ def test_full_config(tox_schema):
         "cpython-beta": "3.13",
         "pypys": ["3.10"],
         "tox-environments-from-pythons": True,
+        "tox-factors": ["ci"],
         "tox-pre-environments": ["spin-up"],
         "tox-post-environments": ["spin-down"],
         "cache-key-prefix": "lint",


### PR DESCRIPTION
Added
-----

-   Add a ``tox-environments-from-pythons`` boolean key
    which will cause a list of tox environments to be generated
    from the list of all configured Python interpreters.

-   Add a ``tox-factors`` config option that will auto-append the factors
    to generated tox environment names.

Changed
-------

-   Guarantee that a stable CPython interpreter is available for tox to use.

    Because tox only offers "best effort" support for PyPy,
    and might not support a given CPython alpha or beta,
    CPython 3.12 will now be set up automatically for tox to use.

    Just prior to running tox, ``actions/setup-python`` will be run again
    to ensure that only the requested Python interpreters are on the PATH.
