### PR TITLE
Fix a typo that prevented the workflow from running correctly

### DIFF
--- a/.github/workflows/create-pr.yaml
+++ b/.github/workflows/create-pr.yaml
@@ -68,7 +68,7 @@ jobs:
         with:
           lookup-only: true
           path: ".create-pr-config.raw.json"
-          key: "create-pr-pr-config-${{ hashFiles('.create-pr-config.raw.json') }}"
+          key: "create-pr-config-${{ hashFiles('.create-pr-config.raw.json') }}"
 
       - name: "Write config schema"
         if: "steps.lookup-config-cache.outputs.cache-hit == false"
@@ -212,7 +212,7 @@ jobs:
         env:
           VERSION: "${{ inputs.version }}"
         run: |
-          ${{ env.venv-path }}/tox run --colored yes -m "${{ fromJSON(inputs.config).tox-commit-prep-label }}"
+          ${{ env.venv-path }}/tox run --colored yes -m "${{ fromJSON(inputs.config).tox-label-create-changes }}"
 
       - name: "Setup Python for commit generation"
         uses: "actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b" # v5.3.0

--- a/changelog.d/20250128_063816_kurtmckee_fixes.rst
+++ b/changelog.d/20250128_063816_kurtmckee_fixes.rst
@@ -1,0 +1,4 @@
+Fixed
+-----
+
+-   ``create-pr``: Fix a typo that prevented the workflow from running correctly.


### PR DESCRIPTION
Fixed
-----

-   ``create-pr``: Fix a typo that prevented the workflow from running correctly.
