### PR TITLE
Set the PR base branch correctly

### DIFF
--- a/.github/workflows/create-pr.yaml
+++ b/.github/workflows/create-pr.yaml
@@ -353,6 +353,6 @@ jobs:
         run: |
           gh pr create \
             --head "${{ fromJSON(inputs.config).branch-name || env.default-branch-name }}" \
-            --base "${{ fromJSON(inputs.config).branch-base || env.default-branch-base }}" \
+            --base "${{ fromJSON(inputs.config).pr-base || env.default-pr-base }}" \
             --title "${{ fromJSON(inputs.config).pr-title || env.default-pr-title }}" \
             --body "${{ fromJSON(inputs.config).pr-body || env.default-pr-body }}"

--- a/changelog.d/20250129_092146_kurtmckee_fix_pr_base.rst
+++ b/changelog.d/20250129_092146_kurtmckee_fix_pr_base.rst
@@ -1,0 +1,4 @@
+Fixed
+-----
+
+-   ``create-pr``: Fix a bug that prevented the PR base branch from being set correctly.


### PR DESCRIPTION
Fixed
-----

-   ``create-pr``: Fix a bug that prevented the PR base branch from being set correctly.
