### PR TITLE
Support skipping tox environments

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -12,6 +12,9 @@ on:
         required: true
         type: "string"
 
+env:
+  CHECK_JSONSCHEMA_VERSION: "0.34.0"
+
 jobs:
   tox:
     name: "tox"
@@ -25,6 +28,11 @@ jobs:
           inputs_config: "${{ inputs.config }}"
         run: |
           echo "$inputs_config" > ".tox-config.raw.json"
+
+      - name: "Setup Python for tox config validation/transformation"
+        uses: "actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c" # v6.0.0
+        with:
+          python-version: "3.13"
 
       # If a previous workflow run successfully validated an identical config object,
       # a cache hit is sufficient to demonstrate that no further validation is required.
@@ -56,6 +64,21 @@ jobs:
                 },
                 "tox-environments": {
                   "description": "A list of tox environments to run.",
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "tox-skip-environments-regex": {
+                  "description": "A regular expression matching tox environments to skip.",
+                  "type": "string",
+                  "format": "regex",
+                  "minLength": 1
+                },
+                "tox-skip-environments": {
+                  "description": "A list of tox environments to skip.",
                   "type": "array",
                   "minItems": 1,
                   "items": {
@@ -172,6 +195,14 @@ jobs:
                       {
                         "description": "tox-environments is mutually exclusive with tox-post-environments.",
                         "not": {"required": ["tox-post-environments"]}
+                      },
+                      {
+                        "description": "tox-environments is mutually exclusive with tox-skip-environments.",
+                        "not": {"required": ["tox-skip-environments"]}
+                      },
+                      {
+                        "description": "tox-environments is mutually exclusive with tox-skip-environments-regex.",
+                        "not": {"required": ["tox-skip-environments-regex"]}
                       }
                     ]
                   }
@@ -184,18 +215,16 @@ jobs:
           # the START and END lines in the JSON schema above must be removed.
           echo "${tox_schema}" | grep -ve '^#' > "${RUNNER_TEMP}/tox-schema.json"
 
-      - name: "Setup Python for tox config validation"
-        if: "steps.lookup-config-cache.outputs.cache-hit == false"
-        uses: "actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c" # v6.0.0
-        with:
-          python-version: "3.13"
-
       - name: "Validate the raw tox config against the schema"
         if: "steps.lookup-config-cache.outputs.cache-hit == false"
         shell: "bash"
         run: |
-          pip install --target="${RUNNER_TEMP}/check-jsonschema" check-jsonschema
-          PYTHONPATH="${RUNNER_TEMP}/check-jsonschema" "${RUNNER_TEMP}/check-jsonschema/bin/check-jsonschema" --schemafile "${RUNNER_TEMP}/tox-schema.json" ".tox-config.raw.json"
+          pip install --target="${RUNNER_TEMP}/check-jsonschema" "check-jsonschema==${CHECK_JSONSCHEMA_VERSION}"
+          export PYTHONPATH="${RUNNER_TEMP}/check-jsonschema"
+          "${RUNNER_TEMP}/check-jsonschema/bin/check-jsonschema" \
+              --schemafile "${RUNNER_TEMP}/tox-schema.json" \
+              --regex-variant python \
+              ".tox-config.raw.json"
 
       - name: "Create a 'config-is-validated' cache key"
         if: "steps.lookup-config-cache.outputs.cache-hit == false"
@@ -212,6 +241,7 @@ jobs:
           import json
           import os
           import pathlib
+          import re
           import typing
 
 
@@ -251,9 +281,17 @@ jobs:
               python_versions_required = python_versions_requested.copy()
               if not cpythons:
                   python_versions_required.append("3.13")
-
               config["python-versions-requested"] = "\n".join(python_versions_requested)
               config["python-versions-required"] = "\n".join(python_versions_required)
+
+              # Prepare the environments to skip.
+              skip_patterns: list[str] = []
+              for environment in config.pop("tox-skip-environments", []):
+                  skip_patterns.append(re.escape(environment))
+              skip_patterns.sort()
+              if pattern := config.pop("tox-skip-environments-regex", ""):
+                  skip_patterns.append(pattern)
+              config["tox-skip-environments-regex"] = "|".join(skip_patterns)
 
 
           def main() -> None:
@@ -354,5 +392,7 @@ jobs:
           allow-prereleases: true
 
       - name: "Run the test suite"
+        env:
+          TOX_SKIP_ENV: "${{ fromJSON(env.tox-config).tox-skip-environments-regex }}"
         run: |
           ${{ env.venv-path }}/tox run --colored yes ${{ fromJSON(env.tox-config).tox-environments && format('-e "{0}"', join(fromJSON(env.tox-config).tox-environments, ',')) }}

--- a/changelog.d/20251002_080559_kurtmckee_skip_environments.rst
+++ b/changelog.d/20251002_080559_kurtmckee_skip_environments.rst
@@ -1,0 +1,5 @@
+Added
+-----
+
+-   Support skipping tox environments via two new config keys:
+    ``tox-skip-environments`` and ``tox-skip-environments-regex``.

--- a/docs/tox.rst
+++ b/docs/tox.rst
@@ -74,6 +74,8 @@ Config keys
     *   ``tox-factors``
     *   ``tox-pre-environments``
     *   ``tox-post-environments``
+    *   ``tox-skip-environments``
+    *   ``tox-skip-environments-regex``
 
     Example:
 
@@ -192,6 +194,61 @@ Config keys
 
         tox run -e "py3.11,pypy3.10,coverage"
                                     ^^^^^^^^
+
+*   ``tox-skip-environments``:
+    An array of tox environment names to skip.
+
+    The names will be sorted, escaped, and combined into a regular expression.
+    Current tox behavior is to *match* -- not *search* -- names against the pattern,
+    so if this option is used, the names must exactly match tox environment names.
+
+    For true regular expression matching, see ``tox-skip-environments-regex`` below.
+
+    Mutually-exclusive with ``tox-environments``.
+
+    Example:
+
+    ..  code-block:: yaml
+
+        cpythons:
+          - "3.13"
+        tox-skip-environments:
+          - "coverage-html"
+          - "docs"
+
+    Resulting tox command:
+
+    ..  code-block::
+
+        export TOX_SKIP_ENVS='coverage-html|docs'
+                              ^^^^^^^^^^^^^ ^^^^
+        tox
+
+*   ``tox-skip-environments-regex``:
+    A regular expression of tox environment names to skip.
+
+    If used with ``tox-skip-environments``, the patterns will be combined.
+
+    Mutually-exclusive with ``tox-environments``.
+
+    Example:
+
+    ..  code-block:: yaml
+
+        cpythons:
+          - "3.13"
+        tox-skip-environments:
+          - "coverage-html"
+          - "docs"
+        tox-skip-environments-regex: "mypy-.*"
+
+    Resulting tox command:
+
+    ..  code-block::
+
+        export TOX_SKIP_ENVS='coverage-html|docs|mypy-.*'
+                              ^^^^^^^^^^^^^ ^^^^ ^^^^^^^
+        tox
 
 *   ``cache-paths``:
     An array of additional paths to cache.

--- a/src/tox-schema.json
+++ b/src/tox-schema.json
@@ -19,6 +19,21 @@
         "minLength": 1
       }
     },
+    "tox-skip-environments-regex": {
+      "description": "A regular expression matching tox environments to skip.",
+      "type": "string",
+      "format": "regex",
+      "minLength": 1
+    },
+    "tox-skip-environments": {
+      "description": "A list of tox environments to skip.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
     "tox-environments-from-pythons": {
       "description": "Generate a list of tox environments from the list of all configured Python interpreters.",
       "type": "boolean",
@@ -128,6 +143,14 @@
           {
             "description": "tox-environments is mutually exclusive with tox-post-environments.",
             "not": {"required": ["tox-post-environments"]}
+          },
+          {
+            "description": "tox-environments is mutually exclusive with tox-skip-environments.",
+            "not": {"required": ["tox-skip-environments"]}
+          },
+          {
+            "description": "tox-environments is mutually exclusive with tox-skip-environments-regex.",
+            "not": {"required": ["tox-skip-environments-regex"]}
           }
         ]
       }

--- a/src/tox_config_transformer.py
+++ b/src/tox_config_transformer.py
@@ -6,6 +6,7 @@
 import json
 import os
 import pathlib
+import re
 import typing
 
 
@@ -45,9 +46,17 @@ def transform_config(config: dict[str, typing.Any]) -> None:
     python_versions_required = python_versions_requested.copy()
     if not cpythons:
         python_versions_required.append("3.13")
-
     config["python-versions-requested"] = "\n".join(python_versions_requested)
     config["python-versions-required"] = "\n".join(python_versions_required)
+
+    # Prepare the environments to skip.
+    skip_patterns: list[str] = []
+    for environment in config.pop("tox-skip-environments", []):
+        skip_patterns.append(re.escape(environment))
+    skip_patterns.sort()
+    if pattern := config.pop("tox-skip-environments-regex", ""):
+        skip_patterns.append(pattern)
+    config["tox-skip-environments-regex"] = "|".join(skip_patterns)
 
 
 def main() -> None:

--- a/tests/test_tox_config_transformer.py
+++ b/tests/test_tox_config_transformer.py
@@ -3,6 +3,8 @@
 # Copyright 2024-2025 Kurt McKee <contactme@kurtmckee.org>
 # SPDX-License-Identifier: MIT
 
+import re
+
 import pytest
 
 import tox_config_transformer
@@ -141,3 +143,32 @@ def test_tox_stable_cpython_injection_unnecessary():
     tox_config_transformer.transform_config(config)
     assert config["python-versions-requested"] == "3.13"
     assert config["python-versions-required"] == "3.13"
+
+
+@pytest.mark.parametrize(
+    "strings, pattern, expected",
+    (
+        (["x.y.z", "abc"], None, r"abc|x\.y\.z"),
+        (None, "mypy-.*", "mypy-.*"),
+        (["x.y.z", "abc"], "mypy-.*", r"abc|x\.y\.z|mypy-.*"),
+    ),
+)
+def test_tox_skip_environments(strings, pattern, expected):
+    """Verify that skipped environments are sorted, escaped, and combined correctly.
+
+    Note that it is expected that the explicit regex pattern will always be at the end;
+    for visibility it is not sorted in with the list of literal environments.
+    """
+
+    config = {
+        "runner": "ubuntu-latest",
+        "cpythons": ["3.13"],
+    }
+    if strings is not None:
+        config["tox-skip-environments"] = strings
+    if pattern is not None:
+        config["tox-skip-environments-regex"] = pattern
+
+    tox_config_transformer.transform_config(config)
+    assert config["tox-skip-environments-regex"] == expected
+    assert re.compile(config["tox-skip-environments-regex"])


### PR DESCRIPTION
Added
-----

-   Support skipping tox environments via two new config keys:
    ``tox-skip-environments`` and ``tox-skip-environments-regex``.
