### PR TITLE
Fix `uv pip install` invocations to use the `--prefix` option

### DIFF
--- a/.github/workflows/create-pr.jinja.yaml
+++ b/.github/workflows/create-pr.jinja.yaml
@@ -163,7 +163,7 @@ jobs:
 
           uv venv --no-project --no-managed-python .venv
           echo "*" > ".venv/.gitignore"
-          uv pip install --no-managed-python --directory=.venv --requirements="${REQUIREMENTS_PATH}"
+          uv pip install --no-managed-python --prefix=.venv --requirements="${REQUIREMENTS_PATH}"
 
       - name: "Setup the requested Python version"
         if: "${{ fromJSON(inputs.config).python-version != '' && fromJSON(inputs.config).python-version != env.PYTHON_VERSION }}"

--- a/.github/workflows/create-pr.yaml
+++ b/.github/workflows/create-pr.yaml
@@ -255,7 +255,7 @@ jobs:
 
           uv venv --no-project --no-managed-python .venv
           echo "*" > ".venv/.gitignore"
-          uv pip install --no-managed-python --directory=.venv --requirements="${REQUIREMENTS_PATH}"
+          uv pip install --no-managed-python --prefix=.venv --requirements="${REQUIREMENTS_PATH}"
 
       - name: "Setup the requested Python version"
         if: "${{ fromJSON(inputs.config).python-version != '' && fromJSON(inputs.config).python-version != env.PYTHON_VERSION }}"

--- a/.github/workflows/tox.jinja.yaml
+++ b/.github/workflows/tox.jinja.yaml
@@ -191,7 +191,7 @@ jobs:
 
           uv venv --no-project --no-managed-python .venv
           Out-File -InputObject "*" -FilePath .venv/.gitignore
-          uv pip install --no-managed-python --directory=.venv --requirements=$REQUIREMENTS_PATH --link-mode=copy
+          uv pip install --no-managed-python --prefix=.venv --requirements=$REQUIREMENTS_PATH --link-mode=copy
 
       - name: "Create a virtual environment (non-Windows)"
         if: "steps.restore-cache.outputs.cache-hit == false && runner.os != 'Windows'"
@@ -202,7 +202,7 @@ jobs:
 
           uv venv --no-project --no-managed-python .venv
           echo "*" > ".venv/.gitignore"
-          uv pip install --no-managed-python --directory=.venv --requirements="${REQUIREMENTS_PATH}"
+          uv pip install --no-managed-python --prefix=.venv --requirements="${REQUIREMENTS_PATH}"
 
       - name: "Setup Pythons (requested)"
         if: "fromJSON(env.TOX_CONFIG).python-versions-required != fromJSON(env.TOX_CONFIG).python-versions-requested"

--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -444,7 +444,7 @@ jobs:
 
           uv venv --no-project --no-managed-python .venv
           Out-File -InputObject "*" -FilePath .venv/.gitignore
-          uv pip install --no-managed-python --directory=.venv --requirements=$REQUIREMENTS_PATH --link-mode=copy
+          uv pip install --no-managed-python --prefix=.venv --requirements=$REQUIREMENTS_PATH --link-mode=copy
 
       - name: "Create a virtual environment (non-Windows)"
         if: "steps.restore-cache.outputs.cache-hit == false && runner.os != 'Windows'"
@@ -455,7 +455,7 @@ jobs:
 
           uv venv --no-project --no-managed-python .venv
           echo "*" > ".venv/.gitignore"
-          uv pip install --no-managed-python --directory=.venv --requirements="${REQUIREMENTS_PATH}"
+          uv pip install --no-managed-python --prefix=.venv --requirements="${REQUIREMENTS_PATH}"
 
       - name: "Setup Pythons (requested)"
         if: "fromJSON(env.TOX_CONFIG).python-versions-required != fromJSON(env.TOX_CONFIG).python-versions-requested"

--- a/changelog.d/20260331_075414_kurtmckee_fix_uv_pip_install.rst
+++ b/changelog.d/20260331_075414_kurtmckee_fix_uv_pip_install.rst
@@ -1,0 +1,7 @@
+Fixed
+-----
+
+-   Fix ``uv pip install`` invocations to use the ``--prefix`` option.
+
+    Previously, the ``--directory`` option was used,
+    which didn't result in e.g. ``.venv/bin/tox`` existing.


### PR DESCRIPTION
Fixed
-----

-   Fix ``uv pip install`` invocations to use the ``--prefix`` option.

    Previously, the ``--directory`` option was used,
    which didn't result in e.g. ``.venv/bin/tox`` existing.
